### PR TITLE
[fix]: add tls support for gRPC client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## [2.0.1] - 2024-10-21
+
+### Fixes
+
+- use TlsConfig with native roots ([#1](https://github.com/rpcpool/yellowstone-grpc-kafka/pull/1))
+
 ## [2.0.0] - 2024-10-04
 
 - Bump solana to to `2.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-kafka"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_yaml = "0.9.25"
 sha2 = { version = "0.10.7", optional = true }
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "fs", "signal", "time", "macros"] }
 tokio-stream = { version = "0.1.11", optional = true }
-tonic = { version = "0.12.1", features = ["gzip", "zstd"], optional = true }
+tonic = { version = "0.12.1", features = ["gzip", "zstd", "tls", "tls-roots"], optional = true }
 tonic-health = { version = "0.12.1", optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
@@ -50,6 +50,7 @@ anyhow = "1.0.62"
 cargo-lock = "9.0.0"
 git-version = "0.3.5"
 vergen = { version = "9.0.0", features = ["build", "rustc"] }
+tonic = { version = "0.12.1", features = ["tls", "tls-roots"] }
 
 [features]
 default = ["kafka"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ anyhow = "1.0.62"
 cargo-lock = "9.0.0"
 git-version = "0.3.5"
 vergen = { version = "9.0.0", features = ["build", "rustc"] }
-tonic = { version = "0.12.1", features = ["tls", "tls-roots"] }
 
 [features]
 default = ["kafka"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-kafka"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Triton One"]
 edition = "2021"
 homepage = "https://triton.one"

--- a/src/bin/grpc-kafka.rs
+++ b/src/bin/grpc-kafka.rs
@@ -6,6 +6,7 @@ use {
     sha2::{Digest, Sha256},
     std::{net::SocketAddr, sync::Arc, time::Duration},
     tokio::task::JoinSet,
+    tonic::transport::ClientTlsConfig,
     tracing::{debug, trace, warn},
     yellowstone_grpc_client::GeyserGrpcClient,
     yellowstone_grpc_kafka::{
@@ -231,6 +232,7 @@ impl ArgsAction {
             .x_token(config.x_token)?
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(5))
+            .tls_config(ClientTlsConfig::new().with_native_roots())?
             .connect()
             .await?;
         let mut geyser = client.subscribe_once(config.request.to_proto()).await?;


### PR DESCRIPTION
Hi @fanatid,

It seems like the TLS for the gRPC client is missing. Please check my patch here.

Thank you very much.