### PR TITLE
fix: probable dedup error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,91 +1,71 @@
+---
 permissions:
   contents: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 on:
   pull_request:
-    paths:
-      - '.github/workflows/release.yml'
+    paths: [.github/workflows/release.yml]
   push:
-    branches:
-      - 'master'
-      - 'v1.18'
-      - 'v2.0'
-      - 'v2.1'
-      - 'v2.2'
-    tags:
-      - 'v*'
+    branches: [master, v1.18, v2.0, v2.1, v2.2]
+    tags: [v*]
   workflow_dispatch:
-
 env:
   CARGO_TERM_COLOR: always
-
 jobs:
   release:
     strategy:
       matrix:
-        os: [ubuntu-22.04,ubuntu-24.04]
-    runs-on: ["${{ matrix.os }}"]
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ['${{ matrix.os }}']
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/cache@v4
         with:
           path: |
-              ~/.cargo/bin/
-              ~/.cargo/registry/index/
-              ~/.cargo/registry/cache/
-              ~/.cargo/git/db/
-              ./target
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}-v001
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./target
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('rust-toolchain.toml') }}-${{
+            hashFiles('**/Cargo.lock') }}-v001
           restore-keys: |
             ${{ matrix.os }}-cargo-${{ hashFiles('rust-toolchain.toml') }}
-
       - name: Set rust version
         run: |
           RUST_VERSION="$(grep -oP 'channel = "\K\d\.\d+\.\d+(?=")' rust-toolchain.toml)"
           echo "RUST_VERSION=$RUST_VERSION" >> "$GITHUB_ENV"
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libsasl2-dev protobuf-compiler
-
       - name: Build release
         run: cargo build --release --bin grpc-kafka
-
       - name: Rename binaries for ubuntu20 release
-        if: matrix.os == 'ubuntu-20.04'
         run: |
-          mv target/release/grpc-kafka target/release/grpc-kafka-20.04
-
+          mv target/release/grpc-kafka target/release/grpc-kafka-${{ matrix.os }}
       - name: Rename binaries for ubuntu22 release
         if: matrix.os == 'ubuntu-22.04'
         run: |
           mv target/release/grpc-kafka target/release/grpc-kafka-22.04
-
       - name: Deleteing directories to avoid upload conflict
         run: |
           rm -rf \
             target/release/grpc-kafka.d
-
       - uses: actions/upload-artifact@v4
         with:
           name: yellowstone-grpc-kafka-${{ github.sha }}-${{ matrix.os }}
           path: |
             target/release/grpc-kafka-*
-
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: |
+          files: |-
             target/release/grpc-kafka-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Build release
         run: cargo build --release --bin grpc-kafka
       - name: Rename binaries for ubuntu20 release
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           mv target/release/grpc-kafka target/release/grpc-kafka-${{ matrix.os }}
       - name: Rename binaries for ubuntu22 release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   release:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04,ubuntu-24.04]
     runs-on: ["${{ matrix.os }}"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04,ubuntu-24.04]
     runs-on: ["${{ matrix.os }}"]
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 config-test.json
 dump.rdb
 *.sw?
+/.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ The minor version will be incremented upon a breaking change and the patch versi
 - Fix deduplication failure when using multiple gRPC sources. Previously hashed the entire 
   SubscribeUpdate including variable metadata (created_at, filters), causing identical 
   messages from different sources to generate different hashes. Now hashes only the 
-  inner update_oneof content, ensuring consistent deduplication across sources.
+  inner update_oneof content for deduplication while preserving the full SubscribeUpdate 
+  message in Kafka, ensuring both consistent deduplication across sources and proper 
+  message format for consumers.
+- Fix kafka2grpc decode errors that occurred with initial dedup fix. The initial fix 
+  incorrectly sent only the inner message content to Kafka, breaking compatibility 
+  with consumers expecting full SubscribeUpdate messages.
 - Bump tokio to 1.45.1 (security advisory)
 - Bump openssl to 0.10.73 (security advisory)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- Duplication error involving sending message with the created_at field which make the sha256 be different,
-resulting on a different update even if its the same.
-- Bump Tokio to `1.45.1`, because of advisory on cargo deny
-- Bump openssl to `0.10.73` for the same reason as Tokio.
+- Fix deduplication failure when using multiple gRPC sources. Previously hashed the entire 
+  SubscribeUpdate including variable metadata (created_at, filters), causing identical 
+  messages from different sources to generate different hashes. Now hashes only the 
+  inner update_oneof content, ensuring consistent deduplication across sources.
+- Bump tokio to 1.45.1 (security advisory)
+- Bump openssl to 0.10.73 (security advisory)
 
 ## [4.0.0] - 2025-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## [4.0.1] - 2025-06-27
+
+### Fixes
+
+- Duplication error involving sending message with the created_at field which make the sha256 be different,
+resulting on a different update even if its the same.
+
 ## [4.0.0] - 2025-03-10
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - Duplication error involving sending message with the created_at field which make the sha256 be different,
 resulting on a different update even if its the same.
+- Bump Tokio to `1.45.1`, because of advisory on cargo deny
+- Bump openssl to `0.10.73` for the same reason as Tokio.
 
 ## [4.0.0] - 2025-03-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-kafka"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,9 +2188,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -5391,9 +5391,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6099,6 +6099,7 @@ dependencies = [
  "hyper-util",
  "json5",
  "lazy_static",
+ "openssl",
  "prometheus",
  "rdkafka",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-grpc-kafka"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["Triton One"]
 edition = "2021"
 description = "Yellowstone gRPC config/request transformers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 yellowstone-grpc-client = { version = "6.0.0", optional = true }
 yellowstone-grpc-proto = "6.0.0"
-openssl = "=0.10.73"
+openssl = "^0.10.73"
 
 [target.'cfg(not(all(target_os = "macos", target_arch = "aarch64")))'.dependencies]
 rdkafka = { version = "0.36.2", features = ["sasl", "ssl"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1.0.145"
 serde_json = "1.0.86"
 serde_yaml = "0.9.25"
 sha2 = { version = "0.10.7", optional = true }
-tokio = { version = "1.21.2", features = ["rt-multi-thread", "fs", "signal", "time", "macros"] }
+tokio = { version = "1.45.1", features = ["rt-multi-thread", "fs", "signal", "time", "macros"] }
 tokio-stream = { version = "0.1.11", optional = true }
 tonic = { version = "0.12.1", features = ["gzip", "zstd", "tls", "tls-roots"], optional = true }
 tonic-health = { version = "0.12.1", optional = true }
@@ -38,6 +38,7 @@ tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 yellowstone-grpc-client = { version = "6.0.0", optional = true }
 yellowstone-grpc-proto = "6.0.0"
+openssl = "=0.10.73"
 
 [target.'cfg(not(all(target_os = "macos", target_arch = "aarch64")))'.dependencies]
 rdkafka = { version = "0.36.2", features = ["sasl", "ssl"], optional = true }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.8'
+
+services:
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9997
+      KAFKA_JMX_HOSTNAME: kafka
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
+      KAFKA_LISTENERS: 'PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+      # Replace CLUSTER_ID with a unique base64 UUID using "bin/kafka-storage.sh random-uuid"
+      # See https://docs.confluent.io/kafka/operations-tools/kafka-tools.html#kafka-storage-sh
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      - kafka
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_METRICS_PORT: 9997
+
+volumes:
+  kafka-data:

--- a/src/bin/grpc-kafka.rs
+++ b/src/bin/grpc-kafka.rs
@@ -282,7 +282,7 @@ impl ArgsAction {
                         UpdateOneof::BlockMeta(msg) => msg.encode_to_vec(),
                         UpdateOneof::Entry(msg) => msg.encode_to_vec(),
                     };
-                    
+
                     let slot = match message {
                         UpdateOneof::Account(msg) => msg.slot,
                         UpdateOneof::Slot(msg) => msg.slot,
@@ -294,7 +294,7 @@ impl ArgsAction {
                         UpdateOneof::BlockMeta(msg) => msg.slot,
                         UpdateOneof::Entry(msg) => msg.slot,
                     };
-                    
+
                     let hash = Sha256::digest(&payload);
                     let key = format!("{slot}_{}", const_hex::encode(hash));
                     let prom_kind = GprcMessageKind::from(message);

--- a/src/bin/grpc-kafka.rs
+++ b/src/bin/grpc-kafka.rs
@@ -266,11 +266,23 @@ impl ArgsAction {
 
             match message {
                 Some(message) => {
-                    let payload = message.encode_to_vec();
                     let message = match &message.update_oneof {
                         Some(value) => value,
                         None => unreachable!("Expect valid message"),
                     };
+
+                    let payload = match message {
+                        UpdateOneof::Account(msg) => msg.encode_to_vec(),
+                        UpdateOneof::Slot(msg) => msg.encode_to_vec(),
+                        UpdateOneof::Transaction(msg) => msg.encode_to_vec(),
+                        UpdateOneof::TransactionStatus(msg) => msg.encode_to_vec(),
+                        UpdateOneof::Block(msg) => msg.encode_to_vec(),
+                        UpdateOneof::Ping(_) => continue,
+                        UpdateOneof::Pong(_) => continue,
+                        UpdateOneof::BlockMeta(msg) => msg.encode_to_vec(),
+                        UpdateOneof::Entry(msg) => msg.encode_to_vec(),
+                    };
+                    
                     let slot = match message {
                         UpdateOneof::Account(msg) => msg.slot,
                         UpdateOneof::Slot(msg) => msg.slot,
@@ -282,6 +294,7 @@ impl ArgsAction {
                         UpdateOneof::BlockMeta(msg) => msg.slot,
                         UpdateOneof::Entry(msg) => msg.slot,
                     };
+                    
                     let hash = Sha256::digest(&payload);
                     let key = format!("{slot}_{}", const_hex::encode(hash));
                     let prom_kind = GprcMessageKind::from(message);


### PR DESCRIPTION
Fix broken dedup with multiple sources

Problem:
- Hashing full SubscribeUpdate struct including metadata
- Same tx from source A and B gets different hash due to created_at/filters
- Dedup fails, duplicates hit kafka

Fix:
- Hash only update_oneof (the actual data)
- Metadata stripped, hash now deterministic
- Same content = same hash regardless of source

Before: hash(SubscribeUpdate{created_at: 123, filters: ["x"], update: tx}) 
After:  hash(tx)
